### PR TITLE
Add support for GNU-like style for find command.

### DIFF
--- a/cmd/go-find/main.go
+++ b/cmd/go-find/main.go
@@ -47,7 +47,7 @@ func init() {
 	fs.Usage = func() {
 		fmt.Printf("Usage:\n\n\t%s [flags..] [paths...]\n", os.Args[0])
 		fmt.Print("\n\tAvailable predicate tests:\n")
-		flag.VisitAll(func(f *flag.Flag) {
+		fs.VisitAll(func(f *flag.Flag) {
 			fmt.Printf("\n\t-%v    \t%v\n", f.Name, f.Usage) // f.Name, f.Value
 		})
 	}

--- a/cmd/go-find/main.go
+++ b/cmd/go-find/main.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/jaytaylor/go-find"
 )
@@ -22,10 +24,13 @@ var (
 	Print0    bool
 )
 
+var fs *flag.FlagSet
+
 func init() {
-	flag.IntVar(&MinDepth, "mindepth", math.MinInt, "Do not apply any tests or actions at levels less than levels (a non-negative integer).  -mindepth 1 means process all files except the starting-points.")
-	flag.IntVar(&MaxDepth, "maxdepth", math.MinInt, "Descend at most levels (a non-negative integer) levels of directories below the starting-points.  -maxdepth 0 means only apply the tests and actions to the starting-points themselves.")
-	flag.StringVar(&Type, "type", "", `File is of type c:
+	fs = flag.NewFlagSet("go-find", flag.ExitOnError)
+	fs.IntVar(&MinDepth, "mindepth", math.MinInt, "Do not apply any tests or actions at levels less than levels (a non-negative integer).  -mindepth 1 means process all files except the starting-points.")
+	fs.IntVar(&MaxDepth, "maxdepth", math.MinInt, "Descend at most levels (a non-negative integer) levels of directories below the starting-points.  -maxdepth 0 means only apply the tests and actions to the starting-points themselves.")
+	fs.StringVar(&Type, "type", "", `File is of type c:
 			c      character (unbuffered) special
 			d      directory
 			p      named pipe (FIFO)
@@ -33,13 +38,13 @@ func init() {
 			l      symbolic link; this is never true if the -L option or the -follow option is in effect, unless the symbolic link is broken.  If you want to search for symbolic links when -L is in effect, use -xtype.
 			s      socket
 		To search for more than one type at once, you can supply the combined list of type letters separated by a comma `+"`"+`,' (GNU extension).`)
-	flag.StringVar(&Name, "name", "", `Base of file name (the path with the leading directories removed) matches shell pattern pattern.  Because the leading directories are removed, the file names considered for a match with -name will never include a slash, so `+"`"+`-name a/b' will never match anything (you probably need to use -path instead).`)
-	flag.StringVar(&WholeName, "wholename", "", `File name matches shell glob pattern.`)
-	flag.StringVar(&Regex, "rege", "", "File name matches regular expression pattern.  This is a match on the whole path, not a search.")
-	flag.BoolVar(&Empty, "empty", false, "File is empty and is either a regular file or a directory.")
-	flag.BoolVar(&Print0, "print0", false, "Print the full file name on the standard output, followed by a null character (instead of the newline character).  This allows file names that contain newlines or other types of white space to be correctly interpreted by programs that process the find output.  This option corresponds to the -0 option of xargs.")
+	fs.StringVar(&Name, "name", "", `Base of file name (the path with the leading directories removed) matches shell pattern pattern.  Because the leading directories are removed, the file names considered for a match with -name will never include a slash, so `+"`"+`-name a/b' will never match anything (you probably need to use -path instead).`)
+	fs.StringVar(&WholeName, "wholename", "", `File name matches shell glob pattern.`)
+	fs.StringVar(&Regex, "rege", "", "File name matches regular expression pattern.  This is a match on the whole path, not a search.")
+	fs.BoolVar(&Empty, "empty", false, "File is empty and is either a regular file or a directory.")
+	fs.BoolVar(&Print0, "print0", false, "Print the full file name on the standard output, followed by a null character (instead of the newline character).  This allows file names that contain newlines or other types of white space to be correctly interpreted by programs that process the find output.  This option corresponds to the -0 option of xargs.")
 
-	flag.Usage = func() {
+	fs.Usage = func() {
 		fmt.Printf("Usage:\n\n\t%s [flags..] [paths...]\n", os.Args[0])
 		fmt.Print("\n\tAvailable predicate tests:\n")
 		flag.VisitAll(func(f *flag.Flag) {
@@ -48,8 +53,22 @@ func init() {
 	}
 }
 
+func getSearchPathsFromCommandLine(args []string) []string {
+	var paths []string
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			break
+		}
+		paths = append(paths, filepath.Clean(arg))
+	}
+	return paths
+}
+
 func main() {
-	args := os.Args
+	args := os.Args[1:]
+	paths := getSearchPathsFromCommandLine(args) // find the search paths to be traversed after the command name
+
+	fs.Parse(args[len(paths):]) // parse the flags after command name and search paths
 	if len(args) > 1 && (args[1] == "-h" || args[1] == "-help" || args[1] == "--help") {
 		flag.Usage()
 		return
@@ -60,10 +79,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error getting current working directory: %s", err)
 		}
-		args = append(args, cwd)
+		paths = append(paths, cwd)
 	}
 
-	finder := find.NewFind(args...)
+	finder := find.NewFind(paths...)
 	if MinDepth != math.MinInt {
 		finder = finder.MinDepth(MinDepth)
 	}


### PR DESCRIPTION
Create a new flagSet to enable parsing from the specific postion of command line arguments( in our case, parse after the given search paths). Thus supporting the GNU-like style for find comand utility.